### PR TITLE
fix on all unsafe.Pointer rules

### DIFF
--- a/pkg/powershell/powershell.go
+++ b/pkg/powershell/powershell.go
@@ -118,9 +118,8 @@ func makePowerShellObjectIndexed(objects uintptr, index uint32) Object {
 	// I don't get why I have to use unsafe.Pointer on C memory
 	var handle nativePowerShell_PowerShellObject
 
-	ptr := unsafe.Pointer(objects)
 	offset := (uintptr(index) * unsafe.Sizeof(handle))
-	handle = *(*nativePowerShell_PowerShellObject)(unsafe.Pointer(uintptr(ptr) + offset))
+	handle = *(*nativePowerShell_PowerShellObject)(unsafe.Pointer(objects + offset))
 	return makePowerShellObject(handle)
 }
 

--- a/pkg/powershell/psh_host.go
+++ b/pkg/powershell/psh_host.go
@@ -46,7 +46,7 @@ type (
 	}
 
 	nativePowerShell_JsonReturnValues struct {
-		objects *nativePowerShell_GenericPowerShellObject
+		objects uintptr // *nativePowerShell_GenericPowerShellObject
 		count   uint32
 	}
 	nativePowerShell_ReceiveJsonCommand func(context uintptr, command nativePowerShell_StringPtr, inputrs *nativePowerShell_PowerShellObject, inputCount uint64, returnValues *nativePowerShell_JsonReturnValues) uintptr

--- a/pkg/powershell/runspace_test.go
+++ b/pkg/powershell/runspace_test.go
@@ -183,7 +183,7 @@ func ExampleCallbackHolder() {
 
 func ExampleRunspace_customSimpleLogger() {
 	// create a custom logger object
-	customLogger := logger.SimpleFuncPtr{func(str string) {
+	customLogger := logger.SimpleFuncPtr{FuncPtr: func(str string) {
 		fmt.Print("Custom: " + str)
 	}}
 	// create a runspace (where you run your powershell statements in)


### PR DESCRIPTION
fix all unsafe.Pointer rule violations
newest version of go still warns in 2 places, those are c memory and are fine